### PR TITLE
Fix issue with disappearing documents picked by UIDocumentPickerViewController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.2.5+1
+### iOS
+- Fix issue with disappearing documents picked by UIDocumentPickerViewController after 1 minute
+
 ## 5.2.5
 ### iOS
 - Fix preprocessor definitions in podspec (thanks @tomk9)

--- a/ios/Classes/FilePickerPlugin.m
+++ b/ios/Classes/FilePickerPlugin.m
@@ -374,8 +374,23 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls{
         _result = nil;
         return;
     }
+
+    // Copying picked documents to NSTemporaryDirectory to avoid automatic cleanup
+    // which happens after the minute of not using the file the directory returned 
+    // by UIDocumentPickerViewController
+    NSMutableArray *updatedUrls = [NSMutableArray new];
+    for (id element in urls){
+        NSURL *fileUrl = element;
+        NSString *fileName = [fileUrl lastPathComponent];
+        NSURL *destination = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:fileName]];
+        
+        if([[NSFileManager defaultManager] isReadableFileAtPath: [fileUrl path]]) {
+            [[NSFileManager defaultManager] copyItemAtURL:fileUrl toURL:destination error:nil];
+            [updatedUrls addObject:destination];
+        }
+    }
     
-    [self handleResult: urls];
+    [self handleResult: updatedUrls];
 }
 #endif // PICKER_DOCUMENT
 

--- a/ios/Classes/FilePickerPlugin.m
+++ b/ios/Classes/FilePickerPlugin.m
@@ -376,8 +376,8 @@ didPickDocumentsAtURLs:(NSArray<NSURL *> *)urls{
     }
 
     // Copying picked documents to NSTemporaryDirectory to avoid automatic cleanup
-    // which happens after the minute of not using the file the directory returned 
-    // by UIDocumentPickerViewController
+    // which happens after one minute of not using the file in the directory 
+    // returned by UIDocumentPickerViewController
     NSMutableArray *updatedUrls = [NSMutableArray new];
     for (id element in urls){
         NSURL *fileUrl = element;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package that allows you to use a native file explorer to pick sin
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
 repository: https://github.com/miguelpruivo/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
-version: 5.2.5
+version: 5.2.5+1
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,8 @@
 name: file_picker
 description: A package that allows you to use a native file explorer to pick single or multiple absolute file paths, with extension filtering support.
 homepage: https://github.com/miguelpruivo/plugins_flutter_file_picker
-repository: https://github.com/miguelpruivo/flutter_file_picker
+publish_to: https://unpub.plentific.com/
+repository: https://github.com/plentific/flutter_file_picker
 issue_tracker: https://github.com/miguelpruivo/flutter_file_picker/issues
 version: 5.2.5+1
 


### PR DESCRIPTION
With this fix, we copy picked documents to NSTemporaryDirectory to avoid automatic cleanup which happens after one minute of not using the file in the directory used by UIDocumentPickerViewController